### PR TITLE
make qvm-open-in-vm call as user

### DIFF
--- a/common/qvm-open-in-vm-we.py
+++ b/common/qvm-open-in-vm-we.py
@@ -18,4 +18,4 @@ if not re.match(".*://.*", msg["url"]):
     sys.exit(1)
 
 #check msg["vmname"]
-os.execvp("qvm-open-in-vm", ["qvm-open-in-vm", msg["vmname"], msg["url"]]);
+os.execvp("sudo", ["sudo", "-u", "user", "qvm-open-in-vm", msg["vmname"], msg["url"]]);


### PR DESCRIPTION
Later firefox requires call to qvm-open-in-vm to be made explicitly as user.
Closes #43  - at least for firefox. I havent other browsers to test.
